### PR TITLE
Include missing .pyf files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,3 +14,4 @@ include assimulo/lib/*.h
 include assimulo/lib/*.c
 include assimulo/thirdparty/dasp3/*
 include assimulo/examples/*
+recursive-include assimulo/thirdparty *.pyf


### PR DESCRIPTION
These are required to rebuild cython extensions from the PyPI archive